### PR TITLE
Fix x-axis label in StreamStatsChart

### DIFF
--- a/web/src/app/components/stream-stats-chart/stream-stats-chart.ts
+++ b/web/src/app/components/stream-stats-chart/stream-stats-chart.ts
@@ -67,7 +67,7 @@ export class StreamStatsChart implements OnChanges {
           enabled: false,
         },
         labels: {
-          formatter: (date) => format((date as unknown) as number, "HH:MM"),
+          formatter: (date) => format((date as unknown) as number, "HH:mm"),
         },
         axisTicks: {
           show: false,


### PR DESCRIPTION
I think it's a typo.
`MM` indicates month and `mm` indicates minutes in javascript datetime.