### PR TITLE
fix(web): fix yagoo channel and twitter

### DIFF
--- a/web/vtubers.ts
+++ b/web/vtubers.ts
@@ -80,8 +80,8 @@ export const vtubers: Record<VTuberIds, VTuber> = {
   },
   yagoo: {
     id: "yagoo",
-    twitter: "hololivetv",
-    youtube: "UCJFZiqLMntJufDCHc6bQixg",
+    twitter: "tanigox",
+    youtube: "UCu2DMOGLeR_DSStCyeQpi5Q",
   },
   sora: {
     id: "sora",


### PR DESCRIPTION
Fix links in `web/vtubers.ts`, with correct channel from `server/srv/vtubers.ts`.

Fixes #572.